### PR TITLE
Update ForeignField to support outside behaviors

### DIFF
--- a/src/foreignField/ForeignField.php
+++ b/src/foreignField/ForeignField.php
@@ -53,11 +53,13 @@ abstract class ForeignField extends Field
    * @inheritDoc
    */
   public function behaviors(): array {
-    return [
-      'typecast' => [
-        'class' => AttributeTypecastBehavior::class,
-      ],
+    $behaviors = parent::behaviors();
+    
+    $behaviors['typecast'] = [
+      'class' => AttributeTypecastBehavior::class,
     ];
+    
+    return $behaviors;
   }
 
   /**


### PR DESCRIPTION
As-is it's impossible for third-party code to add behaviors to any `ForeignField` because the `EVENT_DEFINE_BEHAVIORS` is never called. This adds a call to `parent::behaviors()` so that events are properly triggered.